### PR TITLE
Enable/Disable Probe for WP-FPM

### DIFF
--- a/charts/nginx-stream/Chart.yaml
+++ b/charts/nginx-stream/Chart.yaml
@@ -3,6 +3,6 @@ name: nginx-stream
 description: A Custom Nginx Service with Stream enabled
 
 type: application
-version: 0.2.1
+version: 0.2.2
 
-appVersion: "1.16.2"
+appVersion: "1.16.3"

--- a/charts/nginx-stream/Chart.yaml
+++ b/charts/nginx-stream/Chart.yaml
@@ -3,6 +3,6 @@ name: nginx-stream
 description: A Custom Nginx Service with Stream enabled
 
 type: application
-version: 0.2.0
+version: 0.2.1
 
-appVersion: "1.16.1"
+appVersion: "1.16.2"

--- a/charts/nginx-stream/templates/service.yaml
+++ b/charts/nginx-stream/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   clusterIP: {{ .Values.service.clusterIP }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: 80
       protocol: TCP
       name: http
   selector:

--- a/charts/wordpress-fpm/Chart.yaml
+++ b/charts/wordpress-fpm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wordpress-fpm/Chart.yaml
+++ b/charts/wordpress-fpm/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.2"
+appVersion: "1.16.3"

--- a/charts/wordpress-fpm/Chart.yaml
+++ b/charts/wordpress-fpm/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.2.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.16.2"

--- a/charts/wordpress-fpm/templates/deployment.yaml
+++ b/charts/wordpress-fpm/templates/deployment.yaml
@@ -40,10 +40,12 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- if .Values.enableProbes }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
           env: 
             - name: CHART_NAME
               value: {{ .Chart.Name }}

--- a/charts/wordpress-fpm/templates/service.yaml
+++ b/charts/wordpress-fpm/templates/service.yaml
@@ -10,5 +10,6 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: 9000
       protocol: TCP
+      name: http
   selector:
     {{- include "wordpress-fpm.selectorLabels" . | nindent 4 }}

--- a/charts/wordpress-fpm/values.yaml
+++ b/charts/wordpress-fpm/values.yaml
@@ -71,6 +71,7 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+enableProbes: false
 livenessProbe:
   httpGet:
     path: /

--- a/charts/wordpress-fpm/values.yaml
+++ b/charts/wordpress-fpm/values.yaml
@@ -64,12 +64,12 @@ resources: {}
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-limits:
-  cpu: 100m
-  memory: 128Mi
-requests:
-  cpu: 100m
-  memory: 128Mi
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
 
 livenessProbe:
   httpGet:


### PR DESCRIPTION
Minor updates to nginx port default and disable WP-FPM liveliness probe