### PR TITLE
feat: nginx-stream ConfigMap template for Lua backends SQL data (Phase 9B)

### DIFF
--- a/charts/nginx-stream/Chart.yaml
+++ b/charts/nginx-stream/Chart.yaml
@@ -3,6 +3,6 @@ name: nginx-stream
 description: A Custom Nginx Service with Stream enabled
 
 type: application
-version: 1.0.5
+version: 1.0.6
 
-appVersion: "1.29.3"
+appVersion: "1.29.7"

--- a/charts/nginx-stream/templates/configmap.yaml
+++ b/charts/nginx-stream/templates/configmap.yaml
@@ -15,3 +15,16 @@ data:
     {{ .Values.configmap.config.plainText | nindent 4 }}
 {{- end }}
 {{- end }}
+{{- if .Values.configmap.backendsSqlData }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nginx-stream.fullname" . }}-backends-data
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nginx-stream.labels" . | nindent 4 }}
+data:
+  backends_data.sql: |
+    {{- .Values.configmap.backendsSqlData | nindent 4 }}
+{{- end }}

--- a/charts/nginx-stream/templates/deployment.yaml
+++ b/charts/nginx-stream/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
                   key: CUSTOM_RSYNC_PROXY_SETUP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.volumeMounts .Values.persistence.additionalMounts }}
+          {{- if or .Values.volumeMounts .Values.persistence.additionalMounts .Values.configmap.backendsSqlData }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
              {{- .Values.volumeMounts | toYaml | nindent 12 }}
@@ -66,8 +66,14 @@ spec:
             {{- if .Values.persistence.additionalMounts }}
              {{- .Values.persistence.additionalMounts | toYaml | nindent 12 }}
             {{- end }}
+            {{- if .Values.configmap.backendsSqlData }}
+            - name: backends-data
+              mountPath: {{ .Values.configmap.backendsSqlMountPath }}
+              subPath: backends_data.sql
+              readOnly: true
+            {{- end }}
           {{- end }}
-      {{- if or .Values.volumes .Values.persistence.additionalVolumes }}
+      {{- if or .Values.volumes .Values.persistence.additionalVolumes .Values.configmap.backendsSqlData }}
       volumes:
         {{- if .Values.volumes }}
           {{- .Values.volumes | toYaml | nindent 8}}
@@ -78,6 +84,11 @@ spec:
         {{- end }}
         {{- if .Values.persistence.additionalVolumes }}
           {{- .Values.persistence.additionalVolumes | toYaml | nindent 8}}
+        {{- end }}
+        {{- if .Values.configmap.backendsSqlData }}
+        - name: backends-data
+          configMap:
+            name: {{ include "nginx-stream.fullname" . }}-backends-data
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/nginx-stream/values.yaml
+++ b/charts/nginx-stream/values.yaml
@@ -10,6 +10,8 @@ certManager:
     kind: ClusterIssuer
     name: letsencrypt-prod
 configmap:
+  backendsSqlData: ""
+  backendsSqlMountPath: /opt/lb/lua/backends_data.sql
   config:
     customRsyncProxySetup: /opt/lb/xyz-rsync-client.sh
     decodeBase64: true


### PR DESCRIPTION
Adds `backendsSqlData` support to the `nginx-stream` Helm chart for Lua/SQLite supplemental backend routing.

- **values.yaml** — added `configmap.backendsSqlData` and `configmap.backendsSqlMountPath`
- **templates/configmap.yaml** — conditional second ConfigMap gated by `backendsSqlData`
- **templates/deployment.yaml** — conditional volume + volumeMount for backends-data ConfigMap

Behavior:
- Empty value: zero new resources, identical output
- Non-empty: creates 1 ConfigMap + 1 volume + 1 volumeMount